### PR TITLE
feat: Adds filter expressions to patch operations

### DIFF
--- a/internal/scimpatch/scimpatch.go
+++ b/internal/scimpatch/scimpatch.go
@@ -101,6 +101,12 @@ func applyOp(op Operation, obj *map[string]any) error {
 							} else {
 								return fmt.Errorf("'ew' operator can only be used with string values")
 							}
+						case "pr":
+							if str, ok := v.(string); ok {
+								matches = str != ""
+							} else {
+								matches = v != nil
+							}
 						default:
 							return fmt.Errorf("unsupported filter operator: %q", segment.filter.op)
 						}
@@ -255,6 +261,12 @@ func splitPath(path string) []pathSegment {
 
 func parseFilter(expr string) *filterExpr {
 	parts := strings.Split(expr, " ")
+	if len(parts) == 2 && parts[1] == "pr" {
+		return &filterExpr{
+			attr: parts[0],
+			op:   "pr",
+		}
+	}
 	if len(parts) != 3 {
 		return nil
 	}

--- a/internal/scimpatch/scimpatch.go
+++ b/internal/scimpatch/scimpatch.go
@@ -11,6 +11,24 @@ type Operation struct {
 	Value any    `json:"value"`
 }
 
+type pathSegment struct {
+	name   string
+	filter *filterExpr
+}
+
+type filterExpr struct {
+	attr  string
+	op    string
+	value string
+}
+
+func (p pathSegment) String() string {
+	if p.filter == nil {
+		return p.name
+	}
+	return fmt.Sprintf("%s[%s %s \"%s\"]", p.name, p.filter.attr, p.filter.op, p.filter.value)
+}
+
 func Patch(ops []Operation, obj *map[string]any) error {
 	for _, op := range ops {
 		if err := applyOp(op, obj); err != nil {
@@ -45,25 +63,100 @@ func applyOp(op Operation, obj *map[string]any) error {
 		}
 	}
 
-	for _, segment := range segments[:len(segments)-1] {
-		subV, ok := (*obj)[segment].(map[string]any)
+	current := obj
+	for i, segment := range segments {
+		isLast := i == len(segments)-1
+
+		if segment.filter != nil {
+			arr, ok := (*current)[segment.name].([]any)
+			if !ok {
+				return fmt.Errorf("invalid path: array not found at %q", segment.String())
+			}
+			
+			modified := false
+			for j, item := range arr {
+				if m, ok := item.(map[string]any); ok {
+					if v, exists := m[segment.filter.attr]; exists {
+						matches := false
+						switch segment.filter.op {
+						case "eq":
+							matches = v == segment.filter.value
+						case "ne":
+							matches = v != segment.filter.value
+						default:
+							return fmt.Errorf("unsupported filter operator: %q", segment.filter.op)
+						}
+
+						if matches {
+							modified = true
+							if isLast {
+								if strings.Contains(op.Path, "].") {
+									// If we have a field after the filter, create a new operation for it
+									parts := strings.Split(op.Path, "].")
+									if len(parts) == 2 {
+										newMap := make(map[string]any)
+										for k, v := range m {
+											newMap[k] = v
+										}
+										arr[j] = newMap
+										if err := applyOp(Operation{
+											Op:    op.Op,
+											Path:  parts[1],
+											Value: op.Value,
+										}, &newMap); err != nil {
+											return err
+										}
+									}
+								} else {
+									// If no field after the filter, replace the entire object
+									arr[j] = op.Value
+								}
+							} else {
+								// Not the last segment, continue with the rest of the path
+								newMap := make(map[string]any)
+								for k, v := range m {
+									newMap[k] = v
+								}
+								arr[j] = newMap
+								if err := applyOp(Operation{
+									Op:    op.Op,
+									Path:  strings.Join(segmentsToStrings(segments[i+1:]), "."),
+									Value: op.Value,
+								}, &newMap); err != nil {
+									return err
+								}
+							}
+						}
+					}
+				}
+			}
+			if !modified {
+				return fmt.Errorf("no matching element found for filter %q", segment.String())
+			}
+			(*current)[segment.name] = arr
+			return nil
+		}
+
+		if isLast {
+			if opReplace {
+				(*current)[segment.name] = op.Value
+				return nil
+			}
+			if opAdd {
+				if err := applyAdd(*current, segment.name, op.Value); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		subV, ok := (*current)[segment.name].(map[string]any)
 		if !ok {
-			return fmt.Errorf("invalid path: %q", op.Path)
+			return fmt.Errorf("invalid path: %q", segment.String())
 		}
-
-		obj = &subV
+		current = &subV
 	}
 
-	k := segments[len(segments)-1]
-	if opReplace {
-		(*obj)[k] = op.Value
-		return nil
-	}
-	if opAdd {
-		if err := applyAdd(*obj, k, op.Value); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -111,15 +204,56 @@ var enterpriseUserPrefix = "urn:ietf:params:scim:schemas:extension:enterprise:2.
 // the spec indicates this should mean the "urn:...:2" > "0:User:manager"
 // property. The selective behavior around ":" and "." can't be made to make
 // sense beyond just a straightforward special-casing.
-func splitPath(path string) []string {
+func splitPath(path string) []pathSegment {
 	if path == "" {
 		return nil
 	}
 	if path == enterpriseUserPrefix {
-		return []string{enterpriseUserPrefix}
+		return []pathSegment{{name: enterpriseUserPrefix}}
 	}
 	if strings.HasPrefix(path, enterpriseUserPrefix+":") {
-		return []string{enterpriseUserPrefix, strings.TrimPrefix(path, enterpriseUserPrefix+":")}
+		return []pathSegment{
+			{name: enterpriseUserPrefix},
+			{name: strings.TrimPrefix(path, enterpriseUserPrefix+":")},
+		}
 	}
-	return strings.Split(path, ".")
+
+	var segments []pathSegment
+	for _, part := range strings.Split(path, ".") {
+		if idx := strings.Index(part, "["); idx != -1 {
+			if end := strings.Index(part, "]"); end != -1 {
+				filter := parseFilter(part[idx+1 : end])
+				segments = append(segments, pathSegment{
+					name:   part[:idx],
+					filter: filter,
+				})
+				continue
+			}
+		}
+		segments = append(segments, pathSegment{name: part})
+	}
+	return segments
+}
+
+func parseFilter(expr string) *filterExpr {
+	parts := strings.Split(expr, " ")
+	if len(parts) != 3 {
+		return nil
+	}
+	// Remove quotes from value
+	value := strings.Trim(parts[2], "\"")
+	return &filterExpr{
+		attr:  parts[0],
+		op:    parts[1],
+		value: value,
+	}
+}
+
+// Helper function to convert pathSegments back to strings
+func segmentsToStrings(segments []pathSegment) []string {
+	result := make([]string, len(segments))
+	for i, seg := range segments {
+		result[i] = seg.String()
+	}
+	return result
 }

--- a/internal/scimpatch/scimpatch.go
+++ b/internal/scimpatch/scimpatch.go
@@ -2,6 +2,7 @@ package scimpatch
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -106,6 +107,25 @@ func applyOp(op Operation, obj *map[string]any) error {
 								matches = str != ""
 							} else {
 								matches = v != nil
+							}
+						case "gt", "ge", "lt", "le":
+							switch val := v.(type) {
+							case string:
+								matches = compareStrings(val, segment.filter.value, segment.filter.op)
+							case float64:
+								num, err := strconv.ParseFloat(segment.filter.value, 64)
+								if err != nil {
+									return fmt.Errorf("invalid number in comparison: %q", segment.filter.value)
+								}
+								matches = compareNumbers(val, num, segment.filter.op)
+							case int:
+								num, err := strconv.ParseFloat(segment.filter.value, 64)
+								if err != nil {
+									return fmt.Errorf("invalid number in comparison: %q", segment.filter.value)
+								}
+								matches = compareNumbers(float64(val), num, segment.filter.op)
+							default:
+								return fmt.Errorf("comparison operators can only be used with string or numeric values")
 							}
 						default:
 							return fmt.Errorf("unsupported filter operator: %q", segment.filter.op)
@@ -286,4 +306,34 @@ func segmentsToStrings(segments []pathSegment) []string {
 		result[i] = seg.String()
 	}
 	return result
+}
+
+func compareStrings(a, b, op string) bool {
+	switch op {
+	case "gt":
+		return a > b
+	case "ge":
+		return a >= b
+	case "lt":
+		return a < b
+	case "le":
+		return a <= b
+	default:
+		return false
+	}
+}
+
+func compareNumbers(a, b float64, op string) bool {
+	switch op {
+	case "gt":
+		return a > b
+	case "ge":
+		return a >= b
+	case "lt":
+		return a < b
+	case "le":
+		return a <= b
+	default:
+		return false
+	}
 }

--- a/internal/scimpatch/scimpatch.go
+++ b/internal/scimpatch/scimpatch.go
@@ -72,7 +72,7 @@ func applyOp(op Operation, obj *map[string]any) error {
 			if !ok {
 				return fmt.Errorf("invalid path: array not found at %q", segment.String())
 			}
-			
+
 			modified := false
 			for j, item := range arr {
 				if m, ok := item.(map[string]any); ok {
@@ -94,6 +94,12 @@ func applyOp(op Operation, obj *map[string]any) error {
 								matches = strings.HasPrefix(str, segment.filter.value)
 							} else {
 								return fmt.Errorf("'sw' operator can only be used with string values")
+							}
+						case "ew":
+							if str, ok := v.(string); ok {
+								matches = strings.HasSuffix(str, segment.filter.value)
+							} else {
+								return fmt.Errorf("'ew' operator can only be used with string values")
 							}
 						default:
 							return fmt.Errorf("unsupported filter operator: %q", segment.filter.op)

--- a/internal/scimpatch/scimpatch.go
+++ b/internal/scimpatch/scimpatch.go
@@ -83,6 +83,18 @@ func applyOp(op Operation, obj *map[string]any) error {
 							matches = v == segment.filter.value
 						case "ne":
 							matches = v != segment.filter.value
+						case "co":
+							if str, ok := v.(string); ok {
+								matches = strings.Contains(str, segment.filter.value)
+							} else {
+								return fmt.Errorf("'co' operator can only be used with string values")
+							}
+						case "sw":
+							if str, ok := v.(string); ok {
+								matches = strings.HasPrefix(str, segment.filter.value)
+							} else {
+								return fmt.Errorf("'sw' operator can only be used with string values")
+							}
 						default:
 							return fmt.Errorf("unsupported filter operator: %q", segment.filter.op)
 						}

--- a/internal/scimpatch/scimpatch.go
+++ b/internal/scimpatch/scimpatch.go
@@ -266,10 +266,8 @@ func splitPath(path string) []pathSegment {
 		return []pathSegment{{name: enterpriseUserPrefix}}
 	}
 	if strings.HasPrefix(path, enterpriseUserPrefix+":") {
-		return []pathSegment{
-			{name: enterpriseUserPrefix},
-			{name: strings.TrimPrefix(path, enterpriseUserPrefix+":")},
-		}
+		remainingPath := strings.TrimPrefix(path, enterpriseUserPrefix+":")
+		return append([]pathSegment{{name: enterpriseUserPrefix}}, splitPath(remainingPath)...)
 	}
 
 	var segments []pathSegment

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -120,6 +120,140 @@ func TestPatch(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "replace with filter expression in path",
+			in: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "home",
+						"formatted": "Home 1",
+					},
+					map[string]any{
+						"type":      "work",
+						"formatted": "Work 1",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[type eq \"work\"].formatted", Value: "Remote 1"}},
+			out: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "home",
+						"formatted": "Home 1",
+					},
+					map[string]any{
+						"type":      "work",
+						"formatted": "Remote 1",
+					},
+				},
+			},
+		},
+		{
+			name: "replace entire object with filter expression",
+			in: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "home",
+						"formatted": "Home 1",
+					},
+					map[string]any{
+						"type":      "work",
+						"formatted": "Work 1",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[type eq \"work\"]", Value: map[string]any{
+				"type":      "remote",
+				"formatted": "Remote 1",
+			}}},
+			out: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "home",
+						"formatted": "Home 1",
+					},
+					map[string]any{
+						"type":      "remote",
+						"formatted": "Remote 1",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with not-equal filter expression",
+			in: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "home",
+						"formatted": "Home 1",
+					},
+					map[string]any{
+						"type":      "work",
+						"formatted": "Work 1",
+					},
+					map[string]any{
+						"type":      "other",
+						"formatted": "Other 1",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[type ne \"home\"].formatted", Value: "Remote 1"}},
+			out: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "home",
+						"formatted": "Home 1",
+					},
+					map[string]any{
+						"type":      "work",
+						"formatted": "Remote 1",
+					},
+					map[string]any{
+						"type":      "other",
+						"formatted": "Remote 1",
+					},
+				},
+			},
+		},
+		{
+			name: "replace entire object with not-equal filter expression",
+			in: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "home",
+						"formatted": "Home 1",
+					},
+					map[string]any{
+						"type":      "work",
+						"formatted": "Work 1",
+					},
+					map[string]any{
+						"type":      "other",
+						"formatted": "Other 1",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[type ne \"home\"]", Value: map[string]any{
+				"type":      "remote",
+				"formatted": "Remote 1",
+			}}},
+			out: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "home",
+						"formatted": "Home 1",
+					},
+					map[string]any{
+						"type":      "remote",
+						"formatted": "Remote 1",
+					},
+					map[string]any{
+						"type":      "remote",
+						"formatted": "Remote 1",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -254,6 +254,78 @@ func TestPatch(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "replace with contains filter expression",
+			in: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "home",
+						"formatted": "123 Main St",
+					},
+					map[string]any{
+						"type":      "work",
+						"formatted": "456 Main St",
+					},
+					map[string]any{
+						"type":      "other",
+						"formatted": "789 Side St",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[formatted co \"Main\"].type", Value: "primary"}},
+			out: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "primary",
+						"formatted": "123 Main St",
+					},
+					map[string]any{
+						"type":      "primary",
+						"formatted": "456 Main St",
+					},
+					map[string]any{
+						"type":      "other",
+						"formatted": "789 Side St",
+					},
+				},
+			},
+		},
+		{
+			name: "replace with starts-with filter expression",
+			in: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "home",
+						"formatted": "123 Main St",
+					},
+					map[string]any{
+						"type":      "work",
+						"formatted": "123 Side St",
+					},
+					map[string]any{
+						"type":      "other",
+						"formatted": "456 Main St",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[formatted sw \"123\"].type", Value: "primary"}},
+			out: map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"type":      "primary",
+						"formatted": "123 Main St",
+					},
+					map[string]any{
+						"type":      "primary",
+						"formatted": "123 Side St",
+					},
+					map[string]any{
+						"type":      "other",
+						"formatted": "456 Main St",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -362,6 +362,56 @@ func TestPatch(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "replace with present filter expression",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "bar",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "",
+					},
+					map[string]any{
+						"type": "qux",
+						"str":  nil,
+					},
+					map[string]any{
+						"type": "qux",
+						"str":  "zzz",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str pr].type", Value: "aaa"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "aaa",
+						"str":  "xxx",
+					},
+					map[string]any{
+						"type": "bar",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "",
+					},
+					map[string]any{
+						"type": "qux",
+						"str":  nil,
+					},
+					map[string]any{
+						"type": "aaa",
+						"str":  "zzz",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -326,6 +326,42 @@ func TestPatch(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "replace with ends-with filter expression",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"str":  "xxx_abc",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "yyy_def",
+					},
+					map[string]any{
+						"type": "baz",
+						"str":  "zzz_abc",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str ew \"abc\"].type", Value: "aaa"}},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "aaa",
+						"str":  "xxx_abc",
+					},
+					map[string]any{
+						"type": "bar",
+						"str":  "yyy_def",
+					},
+					map[string]any{
+						"type": "aaa",
+						"str":  "zzz_abc",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -661,6 +661,38 @@ func TestPatch(t *testing.T) {
 			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[date gt \"invalid-date\"].type", Value: "xxx"}},
 			err: "invalid date format in comparison: \"invalid-date\"",
 		},
+		{
+			name: "replace with filter in enterprise user path",
+			in: map[string]any{
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"items": []any{
+						map[string]any{
+							"type": "foo",
+							"str":  "xxx",
+						},
+						map[string]any{
+							"type": "bar",
+							"str":  "yyy",
+						},
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:items[type eq \"bar\"].str", Value: "zzz"}},
+			out: map[string]any{
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"items": []any{
+						map[string]any{
+							"type": "foo",
+							"str":  "xxx",
+						},
+						map[string]any{
+							"type": "bar",
+							"str":  "zzz",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -609,6 +609,58 @@ func TestPatch(t *testing.T) {
 			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[val gt \"true\"].type", Value: "xxx"}},
 			err: "comparison operators can only be used with string or numeric values",
 		},
+		{
+			name: "replace with comparison operators on dates",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"date": "2024-01-01T00:00:00Z",
+					},
+					map[string]any{
+						"type": "bar",
+						"date": "2024-02-01T00:00:00Z",
+					},
+					map[string]any{
+						"type": "baz",
+						"date": "2024-03-01T00:00:00Z",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{
+				{Op: "Replace", Path: "items[date gt \"2024-02-01T00:00:00Z\"].type", Value: "xxx"},
+				{Op: "Replace", Path: "items[date lt \"2024-02-01T00:00:00Z\"].type", Value: "yyy"},
+			},
+			out: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "yyy",
+						"date": "2024-01-01T00:00:00Z",
+					},
+					map[string]any{
+						"type": "bar",
+						"date": "2024-02-01T00:00:00Z",
+					},
+					map[string]any{
+						"type": "xxx",
+						"date": "2024-03-01T00:00:00Z",
+					},
+				},
+			},
+		},
+		{
+			name: "comparison operators with invalid date format should fail",
+			in: map[string]any{
+				"items": []any{
+					map[string]any{
+						"type": "foo",
+						"date": "2024-01-01T00:00:00Z",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[date gt \"invalid-date\"].type", Value: "xxx"}},
+			err: "invalid date format in comparison: \"invalid-date\"",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -123,27 +123,27 @@ func TestPatch(t *testing.T) {
 		{
 			name: "replace with filter expression in path",
 			in: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "home",
-						"formatted": "Home 1",
+						"type": "foo",
+						"str":  "xxx",
 					},
 					map[string]any{
-						"type":      "work",
-						"formatted": "Work 1",
+						"type": "bar",
+						"str":  "yyy",
 					},
 				},
 			},
-			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[type eq \"work\"].formatted", Value: "Remote 1"}},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[type eq \"bar\"].str", Value: "zzz"}},
 			out: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "home",
-						"formatted": "Home 1",
+						"type": "foo",
+						"str":  "xxx",
 					},
 					map[string]any{
-						"type":      "work",
-						"formatted": "Remote 1",
+						"type": "bar",
+						"str":  "zzz",
 					},
 				},
 			},
@@ -151,30 +151,30 @@ func TestPatch(t *testing.T) {
 		{
 			name: "replace entire object with filter expression",
 			in: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "home",
-						"formatted": "Home 1",
+						"type": "foo",
+						"str":  "xxx",
 					},
 					map[string]any{
-						"type":      "work",
-						"formatted": "Work 1",
+						"type": "bar",
+						"str":  "yyy",
 					},
 				},
 			},
-			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[type eq \"work\"]", Value: map[string]any{
-				"type":      "remote",
-				"formatted": "Remote 1",
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[type eq \"bar\"]", Value: map[string]any{
+				"type": "baz",
+				"str":  "zzz",
 			}}},
 			out: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "home",
-						"formatted": "Home 1",
+						"type": "foo",
+						"str":  "xxx",
 					},
 					map[string]any{
-						"type":      "remote",
-						"formatted": "Remote 1",
+						"type": "baz",
+						"str":  "zzz",
 					},
 				},
 			},
@@ -182,35 +182,35 @@ func TestPatch(t *testing.T) {
 		{
 			name: "replace with not-equal filter expression",
 			in: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "home",
-						"formatted": "Home 1",
+						"type": "foo",
+						"str":  "xxx",
 					},
 					map[string]any{
-						"type":      "work",
-						"formatted": "Work 1",
+						"type": "bar",
+						"str":  "yyy",
 					},
 					map[string]any{
-						"type":      "other",
-						"formatted": "Other 1",
+						"type": "baz",
+						"str":  "zzz",
 					},
 				},
 			},
-			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[type ne \"home\"].formatted", Value: "Remote 1"}},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[type ne \"foo\"].str", Value: "aaa"}},
 			out: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "home",
-						"formatted": "Home 1",
+						"type": "foo",
+						"str":  "xxx",
 					},
 					map[string]any{
-						"type":      "work",
-						"formatted": "Remote 1",
+						"type": "bar",
+						"str":  "aaa",
 					},
 					map[string]any{
-						"type":      "other",
-						"formatted": "Remote 1",
+						"type": "baz",
+						"str":  "aaa",
 					},
 				},
 			},
@@ -218,38 +218,38 @@ func TestPatch(t *testing.T) {
 		{
 			name: "replace entire object with not-equal filter expression",
 			in: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "home",
-						"formatted": "Home 1",
+						"type": "foo",
+						"str":  "xxx",
 					},
 					map[string]any{
-						"type":      "work",
-						"formatted": "Work 1",
+						"type": "bar",
+						"str":  "yyy",
 					},
 					map[string]any{
-						"type":      "other",
-						"formatted": "Other 1",
+						"type": "baz",
+						"str":  "zzz",
 					},
 				},
 			},
-			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[type ne \"home\"]", Value: map[string]any{
-				"type":      "remote",
-				"formatted": "Remote 1",
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[type ne \"foo\"]", Value: map[string]any{
+				"type": "aaa",
+				"str":  "bbb",
 			}}},
 			out: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "home",
-						"formatted": "Home 1",
+						"type": "foo",
+						"str":  "xxx",
 					},
 					map[string]any{
-						"type":      "remote",
-						"formatted": "Remote 1",
+						"type": "aaa",
+						"str":  "bbb",
 					},
 					map[string]any{
-						"type":      "remote",
-						"formatted": "Remote 1",
+						"type": "aaa",
+						"str":  "bbb",
 					},
 				},
 			},
@@ -257,35 +257,35 @@ func TestPatch(t *testing.T) {
 		{
 			name: "replace with contains filter expression",
 			in: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "home",
-						"formatted": "123 Main St",
+						"type": "foo",
+						"str":  "xxx_abc",
 					},
 					map[string]any{
-						"type":      "work",
-						"formatted": "456 Main St",
+						"type": "bar",
+						"str":  "yyy_abc",
 					},
 					map[string]any{
-						"type":      "other",
-						"formatted": "789 Side St",
+						"type": "baz",
+						"str":  "zzz",
 					},
 				},
 			},
-			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[formatted co \"Main\"].type", Value: "primary"}},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str co \"abc\"].type", Value: "aaa"}},
 			out: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "primary",
-						"formatted": "123 Main St",
+						"type": "aaa",
+						"str":  "xxx_abc",
 					},
 					map[string]any{
-						"type":      "primary",
-						"formatted": "456 Main St",
+						"type": "aaa",
+						"str":  "yyy_abc",
 					},
 					map[string]any{
-						"type":      "other",
-						"formatted": "789 Side St",
+						"type": "baz",
+						"str":  "zzz",
 					},
 				},
 			},
@@ -293,35 +293,35 @@ func TestPatch(t *testing.T) {
 		{
 			name: "replace with starts-with filter expression",
 			in: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "home",
-						"formatted": "123 Main St",
+						"type": "foo",
+						"str":  "xxx_abc",
 					},
 					map[string]any{
-						"type":      "work",
-						"formatted": "123 Side St",
+						"type": "bar",
+						"str":  "xxx_def",
 					},
 					map[string]any{
-						"type":      "other",
-						"formatted": "456 Main St",
+						"type": "baz",
+						"str":  "yyy_abc",
 					},
 				},
 			},
-			ops: []scimpatch.Operation{{Op: "Replace", Path: "addresses[formatted sw \"123\"].type", Value: "primary"}},
+			ops: []scimpatch.Operation{{Op: "Replace", Path: "items[str sw \"xxx\"].type", Value: "aaa"}},
 			out: map[string]any{
-				"addresses": []any{
+				"items": []any{
 					map[string]any{
-						"type":      "primary",
-						"formatted": "123 Main St",
+						"type": "aaa",
+						"str":  "xxx_abc",
 					},
 					map[string]any{
-						"type":      "primary",
-						"formatted": "123 Side St",
+						"type": "aaa",
+						"str":  "xxx_def",
 					},
 					map[string]any{
-						"type":      "other",
-						"formatted": "456 Main St",
+						"type": "baz",
+						"str":  "yyy_abc",
 					},
 				},
 			},


### PR DESCRIPTION
This adds support for filter expressions in the path for patch replace operations according to the SCIM spec.

IMPORTANT: We are currently not supporting logical expressions or grouping!