### PR TITLE
fix: Show failed status badge for non-2xx SCIM requests

### DIFF
--- a/app/src/pages/ViewSCIMDirectoryPage.tsx
+++ b/app/src/pages/ViewSCIMDirectoryPage.tsx
@@ -570,9 +570,14 @@ function RequestsCard() {
                     {moment(scimRequest.timestamp!.toDate()).format()}
                   </TableCell>
                   <TableCell>
-                    {!scimRequest.error.case && (
-                      <Badge variant="outline">Success</Badge>
-                    )}
+                    {!scimRequest.error.case ? (
+                      scimRequest.httpResponseStatus >
+                      SCIMRequestHTTPStatus.SCIM_REQUEST_HTTP_STATUS_204 ? (
+                        <Badge variant="destructive">Failed</Badge>
+                      ) : (
+                        <Badge variant="outline">Success</Badge>
+                      )
+                    ) : null}
                     {scimRequest?.error?.case === "badBearerToken" && (
                       <Badge variant="destructive">Bad bearer token</Badge>
                     )}


### PR DESCRIPTION
Previously, the SCIM requests table would show a "Success" badge for requests that failed with non-2xx status codes (like 400 Bad Request). This was misleading as these requests actually failed.
Changes:
- Updated the status badge logic in the SCIM requests table to show "Failed" for any response with status code > 204
- Maintained existing error-specific badges (bad bearer token, bad username, bad email domain)
This change ensures that the status badge accurately reflects the outcome of the request, making it easier to identify failed requests directly from the table view without having to check the request details.