### PR TITLE
Fix SCIM filtered user query to convert manager field to complex reference

### DIFF
--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -85,9 +85,7 @@ func (s *Service) scimListUsers(w http.ResponseWriter, r *http.Request) error {
 			panic(err)
 		}
 
-		resource := scimUser.Attributes.AsMap()
-		resource["id"] = scimUser.Id
-		resource["userName"] = scimUser.Email
+		resource := scimUserToResource(scimUser)
 
 		w.Header().Set("Content-Type", "application/scim+json")
 		w.WriteHeader(http.StatusOK)

--- a/internal/authservice/scim_test.go
+++ b/internal/authservice/scim_test.go
@@ -39,6 +39,61 @@ func TestSCIMUserToResource_ManagerReference(t *testing.T) {
 			},
 		},
 		{
+			name: "realistic user with full enterprise attributes and manager",
+			input: &ssoreadyv1.SCIMUser{
+				Id:    "scim_user_6ytool3syktvl99vb3ingqzqi",
+				Email: "karstaedt@sport-thieme.de",
+				Attributes: mustNewStruct(map[string]any{
+					"active": true,
+					"displayName": "Nikolas Karstaedt",
+					"emails": []any{
+						map[string]any{
+							"primary": true,
+							"type":    "work",
+							"value":   "karstaedt@sport-thieme.de",
+						},
+					},
+					"externalId": "karstaedt",
+					"name": map[string]any{
+						"familyName": "Karstaedt",
+						"formatted":  "Nikolas Karstaedt",
+						"givenName":  "Nikolas",
+					},
+					"title": "Business Intelligence Entwickler",
+					"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+						"department": "Business Intelligence",
+						"manager":    "scim_user_cldgopimpfk79l2lwlyammhck",
+					},
+				}),
+			},
+			expected: map[string]any{
+				"id":       "scim_user_6ytool3syktvl99vb3ingqzqi",
+				"userName": "karstaedt@sport-thieme.de",
+				"active":   true,
+				"displayName": "Nikolas Karstaedt",
+				"emails": []any{
+					map[string]any{
+						"primary": true,
+						"type":    "work",
+						"value":   "karstaedt@sport-thieme.de",
+					},
+				},
+				"externalId": "karstaedt",
+				"name": map[string]any{
+					"familyName": "Karstaedt",
+					"formatted":  "Nikolas Karstaedt",
+					"givenName":  "Nikolas",
+				},
+				"title": "Business Intelligence Entwickler",
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]any{
+					"department": "Business Intelligence",
+					"manager": map[string]any{
+						"value": "scim_user_cldgopimpfk79l2lwlyammhck",
+					},
+				},
+			},
+		},
+		{
 			name: "already complex manager reference is preserved",
 			input: &ssoreadyv1.SCIMUser{
 				Id:    "user123",


### PR DESCRIPTION
## Problem

The filtered user query path in `scimListUsers()` was inconsistent with other endpoints. It manually constructed the resource response instead of using the shared `scimUserToResource()` helper function.

This caused the filtered query endpoint to bypass important transformations that were applied by other endpoints, specifically:
- Manager field conversion from simple string to complex reference object (required by SCIM Enterprise User Schema)
- Active property normalization for Entra ID compatibility