### PR TITLE
feat: Support non-email usernames in SCIM and fix case-sensitive domain validation

### DIFF
--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -269,7 +269,7 @@ func (s *Service) scimCreateUser(w http.ResponseWriter, r *http.Request) error {
 
 	var domainOk bool
 	for _, domain := range allowedDomains {
-		if emailDomain == domain {
+		if emailDomain == strings.ToLower(domain) {
 			domainOk = true
 		}
 	}
@@ -371,7 +371,7 @@ func (s *Service) scimUpdateUser(w http.ResponseWriter, r *http.Request) error {
 
 	var domainOk bool
 	for _, domain := range allowedDomains {
-		if emailDomain == domain {
+		if emailDomain == strings.ToLower(domain) {
 			domainOk = true
 		}
 	}
@@ -482,7 +482,7 @@ func (s *Service) scimPatchUser(w http.ResponseWriter, r *http.Request) error {
 
 	var domainOk bool
 	for _, domain := range allowedDomains {
-		if emailDomain == domain {
+		if emailDomain == strings.ToLower(domain) {
 			domainOk = true
 		}
 	}

--- a/internal/authservice/scim.go
+++ b/internal/authservice/scim.go
@@ -56,6 +56,7 @@ func (s *Service) scimListUsers(w http.ResponseWriter, r *http.Request) error {
 			panic("unsupported filter param")
 		}
 
+		// scimvalidator.microsoft.com sends url-encoded values; harmless to "normal" emails to url-parse them
 		filterField := match[1]
 		filterValue, err := url.QueryUnescape(match[2])
 		if err != nil {
@@ -895,7 +896,7 @@ func (s *Service) scimPatchGroup(w http.ResponseWriter, r *http.Request) error {
 func scimUserToResource(scimUser *ssoreadyv1.SCIMUser) map[string]any {
 	r := scimUser.Attributes.AsMap()
 	r["id"] = scimUser.Id
-	
+
 	// userName is stored in attributes. If not present, fallback to email for backward compatibility
 	if _, ok := r["userName"]; !ok {
 		r["userName"] = scimUser.Email

--- a/internal/authservice/scim_test.go
+++ b/internal/authservice/scim_test.go
@@ -530,6 +530,53 @@ func TestSCIMUserFromResource(t *testing.T) {
 	}
 }
 
+func TestEmailDomainExtraction(t *testing.T) {
+	tests := []struct {
+		name           string
+		email          string
+		expectedDomain string
+		expectError    bool
+	}{
+		{
+			name:           "lowercase domain",
+			email:          "user@example.com",
+			expectedDomain: "example.com",
+			expectError:    false,
+		},
+		{
+			name:           "mixed case domain - extracted as lowercase",
+			email:          "alex@OmnifactGmbH.onmicrosoft.com",
+			expectedDomain: "omnifactgmbh.onmicrosoft.com",
+			expectError:    false,
+		},
+		{
+			name:           "uppercase domain - extracted as lowercase",
+			email:          "user@EXAMPLE.COM",
+			expectedDomain: "example.com",
+			expectError:    false,
+		},
+		{
+			name:           "subdomain with mixed case",
+			email:          "user@Mail.Example.COM",
+			expectedDomain: "mail.example.com",
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			domain, err := emailaddr.Parse(tt.email)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedDomain, domain, "Domain should be extracted as lowercase")
+			}
+		})
+	}
+}
+
 func TestEmailFormatDetection(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

This PR extends SCIM user provisioning to support non-email usernames while maintaining backward compatibility with existing implementations. It also fixes a case-sensitivity bug in email domain validation.

## Changes

### 1. Non-Email Username Support

- **Email Extraction**: Added `extractEmailFromResource()` to extract email from the `emails` array (SCIM 2.0 spec compliant)
  - Prefers email marked with `primary: true`
  - Falls back to first email if no primary specified
  - Returns error if no valid email found

- **Storage**: 
  - `userName` can now be any value (e.g., `"m.test"`, `"John"`, UUIDs, etc.)
  - Email is extracted from `emails` array and stored in the `email` column for uniqueness constraint
  - `userName` is preserved in the `attributes` JSONB field

- **Filter Optimization**: Smart filtering for `userName eq "value"` queries
  - If filter value is email format → search `email` column first (backward compatibility), fallback to `attributes`
  - If filter value is NOT email format → directly search `attributes` (skip email column for better performance)
  - `email.value eq "value"` queries continue to search only the `email` column

- **Response Format**: `scimUserToResource()` returns `userName` from attributes, fallbacks to `email` for old data

### 2. Case-Insensitive Domain Validation Fix

**Bug**: Email domain comparison was case-sensitive, causing valid requests to fail
- Example: `john@Example.com` was rejected even when `example.com` was an allowed domain
- `emailaddr.Parse()` returns lowercase domains, but allowed domains from DB kept original casing

**Fix**: Lowercase allowed domains before comparison
if emailDomain == strings.ToLower(domain) {
    domainOk = true
}
