### PR TITLE
fix: Local Setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
+# Database Configuration
+POSTGRES_PORT=5432
+
+# API Service Configuration
 API_SERVE_ADDR=localhost:8081
 API_DB=postgres://postgres:password@localhost/postgres
 API_DEFAULT_AUTH_URL=http://localhost:8080
+API_DEFAULT_ADMIN_SETUP_URL=http://localhost:8083/setup
 API_EMAIL_CHALLENGE_FROM=onboarding@resend.dev
 API_EMAIL_VERIFICATION_ENDPOINT=http://localhost:8082/verify-email
 API_SENTRY_DSN=...

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,6 @@ services:
     environment:
       POSTGRES_PASSWORD: "password"
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - ./.postgres:/var/lib/postgresql/data


### PR DESCRIPTION
Updates the `.env.example` to use the right self service url and `docker-compose.yaml` to be able to set a dynamic db port.