### PR TITLE
feat: Self Service: Adds copy button to scim url and bearer token

### DIFF
--- a/admin/src/components/ValueCopier.tsx
+++ b/admin/src/components/ValueCopier.tsx
@@ -1,0 +1,58 @@
+import { offset, useFloating, useTransitionStyles } from "@floating-ui/react";
+import { CopyIcon } from "lucide-react";
+import React, { useCallback, useEffect, useState } from "react";
+
+export function ValueCopier({ value }: { value: string }) {
+  const [open, setOpen] = useState(false);
+  const { refs, floatingStyles, context } = useFloating({
+    open,
+    onOpenChange: setOpen,
+    placement: "top",
+    middleware: [offset(5)],
+  });
+  const { isMounted, styles } = useTransitionStyles(context, {
+    duration: 150,
+    initial: { opacity: 0, transform: "translateY(0)" },
+    open: { opacity: 1, transform: "translateY(-5px)" },
+  });
+
+  useEffect(() => {
+    if (open) {
+      const timeoutId = setTimeout(() => {
+        setOpen(false);
+      }, 1000);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [open]);
+
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(value);
+    setOpen(true);
+  }, [value, setOpen]);
+
+  return (
+    <div
+      ref={refs.setReference}
+      onClick={handleCopy}
+      className="flex select-none cursor-pointer bg-muted font-mono text-xs border border-input rounded-md px-3 py-2"
+    >
+      <span>{value}</span>
+      <span className="ml-auto flex gap-x-2">
+        <CopyIcon className="cursor-pointer text-muted-foreground hover:text-foreground h-4 w-4" />
+      </span>
+
+      {open && (
+        <div ref={refs.setFloating} style={floatingStyles}>
+          {isMounted && (
+            <div
+              style={styles}
+              className="font-sans bg-black text-white px-2 py-1 text-xs rounded"
+            >
+              Copied!
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin/src/pages/SetupSAMLConnectionPage.tsx
+++ b/admin/src/pages/SetupSAMLConnectionPage.tsx
@@ -1,10 +1,9 @@
-import React, { ReactNode, useCallback, useEffect, useState } from "react";
+import React, { ReactNode, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import {
   CheckIcon,
   ChevronDownIcon,
   ChevronRightIcon,
-  CopyIcon,
 } from "lucide-react";
 import {
   Card,
@@ -15,13 +14,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useParams } from "react-router";
-import {
-  offset,
-  useFloating,
-  useHover,
-  useInteractions,
-  useTransitionStyles,
-} from "@floating-ui/react";
+import { ValueCopier } from "@/components/ValueCopier";
 import {
   createConnectQueryKey,
   useMutation,
@@ -467,61 +460,6 @@ function Steps({ steps, currentStep }: { steps: Step[]; currentStep: number }) {
           </div>
         ))}
       </div>
-    </div>
-  );
-}
-
-function ValueCopier({ value }: { value: string }) {
-  const [open, setOpen] = useState(false);
-  const { refs, floatingStyles, context } = useFloating({
-    open,
-    onOpenChange: setOpen,
-    placement: "top",
-    middleware: [offset(5)],
-  });
-  const { isMounted, styles } = useTransitionStyles(context, {
-    duration: 150,
-    initial: { opacity: 0, transform: "translateY(0)" },
-    open: { opacity: 1, transform: "translateY(-5px)" },
-  });
-
-  useEffect(() => {
-    if (open) {
-      const timeoutId = setTimeout(() => {
-        setOpen(false);
-      }, 1000);
-      return () => clearTimeout(timeoutId);
-    }
-  }, [open]);
-
-  const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(value);
-    setOpen(true);
-  }, [value, setOpen]);
-
-  return (
-    <div
-      ref={refs.setReference}
-      onClick={handleCopy}
-      className="flex select-none cursor-pointer bg-muted font-mono text-xs border border-input rounded-md px-3 py-2"
-    >
-      <span>{value}</span>
-      <span className="ml-auto flex gap-x-2">
-        <CopyIcon className="cursor-pointer text-muted-foreground hover:text-foreground h-4 w-4" />
-      </span>
-
-      {open && (
-        <div ref={refs.setFloating} style={floatingStyles}>
-          {isMounted && (
-            <div
-              style={styles}
-              className="font-sans bg-black text-white px-2 py-1 text-xs rounded"
-            >
-              Copied!
-            </div>
-          )}
-        </div>
-      )}
     </div>
   );
 }

--- a/admin/src/pages/ViewSCIMDirectoryPage.tsx
+++ b/admin/src/pages/ViewSCIMDirectoryPage.tsx
@@ -1,5 +1,6 @@
 import { LayoutMain } from "@/components/Layout";
-import React, { useCallback, useState } from "react";
+import { ValueCopier } from "@/components/ValueCopier";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -11,8 +12,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { CircleAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -20,35 +20,36 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { useParams } from "react-router";
 import {
-  createConnectQueryKey,
-  useMutation,
-  useQuery,
-} from "@connectrpc/connect-query";
-import {
-  adminGetSCIMDirectory,
-  adminRotateSCIMDirectoryBearerToken,
-  adminUpdateSCIMDirectory,
-} from "@/gen/ssoready/v1/ssoready-SSOReadyService_connectquery";
-import { useQueryClient } from "@tanstack/react-query";
-import { z } from "zod";
-import { useForm } from "react-hook-form";
-import { Button } from "@/components/ui/button";
-import { SCIMDirectory } from "@/gen/ssoready/v1/ssoready_pb";
-import { zodResolver } from "@hookform/resolvers/zod";
-import {
+  Form,
   FormControl,
   FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
-  Form,
 } from "@/components/ui/form";
 import { Switch } from "@/components/ui/switch";
+import {
+  adminGetSCIMDirectory,
+  adminRotateSCIMDirectoryBearerToken,
+  adminUpdateSCIMDirectory,
+} from "@/gen/ssoready/v1/ssoready-SSOReadyService_connectquery";
+import { SCIMDirectory } from "@/gen/ssoready/v1/ssoready_pb";
 import { useTitle } from "@/useTitle";
+import {
+  createConnectQueryKey,
+  useMutation,
+  useQuery,
+} from "@connectrpc/connect-query";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { CircleAlert } from "lucide-react";
+import React, { useCallback, useState } from "react";
 import { Helmet } from "react-helmet";
+import { useForm } from "react-hook-form";
+import { useParams } from "react-router";
+import { z } from "zod";
 
 export function ViewSCIMDirectoryPage() {
   const { scimDirectoryId } = useParams();
@@ -135,9 +136,7 @@ export function ViewSCIMDirectoryPage() {
             SCIM Bearer Token
           </div>
 
-          <div className="text-xs font-mono bg-gray-100 py-2 px-4 rounded-sm border">
-            {bearerToken}
-          </div>
+          <ValueCopier value={bearerToken} />
 
           <AlertDialogFooter>
             <AlertDialogCancel>Close</AlertDialogCancel>
@@ -180,8 +179,12 @@ export function ViewSCIMDirectoryPage() {
               <div className="text-sm col-span-1 text-muted-foreground">
                 SCIM Base URL
               </div>
-              <div className="text-sm col-span-3">
-                {scimDirectory?.scimDirectory?.scimBaseUrl}
+              <div className="col-span-3">
+                {scimDirectory?.scimDirectory?.scimBaseUrl && (
+                  <ValueCopier
+                    value={scimDirectory.scimDirectory.scimBaseUrl}
+                  />
+                )}
               </div>
             </div>
           </CardContent>


### PR DESCRIPTION
During the self service scim setup we are missing copy buttons for the SCIM URL and the generated bearer token. Now we have extracted the copy value logic we already use in the SAML setup and also use it in the SCIM setup.