### PR TITLE
fix: SCIM PATCH top-level replace handling and support stringified object values

### DIFF
--- a/internal/scimpatch/scimpatch.go
+++ b/internal/scimpatch/scimpatch.go
@@ -1,6 +1,7 @@
 package scimpatch
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -89,11 +90,16 @@ func applyOp(op Operation, obj *map[string]any) error {
 	// Regular path handling (non-enterprise user schema)
 	if len(segments) == 0 {
 		if opReplace {
-			val, ok := op.Value.(map[string]any)
-			if !ok {
-				return fmt.Errorf("top-level 'replace' operation must have an object value")
+			val, err := topLevelObjectValue(op.Value)
+			if err != nil {
+				return err
 			}
-			*obj = val
+
+			// RFC 7644 allows `replace` without a path to provide a set of
+			// attributes to replace on the target resource.
+			for k, v := range val {
+				applyTopLevelReplaceAttribute(*obj, k, v)
+			}
 			return nil
 		}
 		if opAdd {
@@ -297,6 +303,57 @@ func applyAdd(obj map[string]any, k string, v any) error {
 	default:
 		obj[k] = v
 		return nil
+	}
+}
+
+func topLevelObjectValue(v any) (map[string]any, error) {
+	if m, ok := v.(map[string]any); ok {
+		return m, nil
+	}
+
+	// Some providers send a JSON object as a string-valued PATCH value.
+	// Accept that form for compatibility.
+	s, ok := v.(string)
+	if !ok {
+		return nil, fmt.Errorf("top-level 'replace' operation must have an object value")
+	}
+
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, fmt.Errorf("top-level 'replace' operation must have an object value")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		return nil, fmt.Errorf("top-level 'replace' operation must have an object value")
+	}
+	if parsed == nil {
+		return nil, fmt.Errorf("top-level 'replace' operation must have an object value")
+	}
+	return parsed, nil
+}
+
+func applyTopLevelReplaceAttribute(obj map[string]any, key string, incoming any) {
+	// Compatibility behavior: when replacing top-level attributes with an
+	// object value, merge recursively instead of dropping existing siblings.
+	if existing, ok := obj[key].(map[string]any); ok {
+		if incomingMap, ok := incoming.(map[string]any); ok {
+			deepMergeMaps(existing, incomingMap)
+			return
+		}
+	}
+	obj[key] = incoming
+}
+
+func deepMergeMaps(dst map[string]any, src map[string]any) {
+	for key, srcVal := range src {
+		if dstMap, ok := dst[key].(map[string]any); ok {
+			if srcMap, ok := srcVal.(map[string]any); ok {
+				deepMergeMaps(dstMap, srcMap)
+				continue
+			}
+		}
+		dst[key] = srcVal
 	}
 }
 

--- a/internal/scimpatch/scimpatch_test.go
+++ b/internal/scimpatch/scimpatch_test.go
@@ -17,16 +17,108 @@ func TestPatch(t *testing.T) {
 		err  string
 	}{
 		{
-			name: "replace entire value",
+			name: "replace top-level attributes with empty path",
 			in:   map[string]any{"foo": "xxx"},
 			ops:  []scimpatch.Operation{{Op: "replace", Path: "", Value: map[string]any{"bar": "yyy"}}},
-			out:  map[string]any{"bar": "yyy"},
+			out:  map[string]any{"foo": "xxx", "bar": "yyy"},
 		},
 		{
 			name: "replace entire value with non-object",
 			in:   map[string]any{"foo": "xxx"},
 			ops:  []scimpatch.Operation{{Op: "replace", Path: "", Value: "notanobject"}},
 			err:  "top-level 'replace' operation must have an object value",
+		},
+		{
+			name: "replace top-level attributes with empty path and stringified object value",
+			in: map[string]any{
+				"userName": "old@example.com",
+				"name": map[string]any{
+					"givenName": "Old",
+					"nested": map[string]any{
+						"keep": "value",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{
+				Op:   "replace",
+				Path: "",
+				Value: "{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:User\"]," +
+					"\"name\":{\"familyName\":\"Test-V3\"}}",
+			}},
+			out: map[string]any{
+				"userName": "old@example.com",
+				"schemas":  []any{"urn:ietf:params:scim:schemas:core:2.0:User"},
+				"name": map[string]any{
+					"familyName": "Test-V3",
+					"givenName":  "Old",
+					"nested": map[string]any{
+						"keep": "value",
+					},
+				},
+			},
+		},
+		{
+			name: "replace top-level attributes with empty path and object value",
+			in: map[string]any{
+				"userName": "old@example.com",
+				"name": map[string]any{
+					"givenName": "Old",
+					"nested": map[string]any{
+						"keep": "value",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{
+				Op:   "replace",
+				Path: "",
+				Value: map[string]any{
+					"schemas": []any{"urn:ietf:params:scim:schemas:core:2.0:User"},
+					"name": map[string]any{
+						"familyName": "Test-V3",
+					},
+				},
+			}},
+			out: map[string]any{
+				"userName": "old@example.com",
+				"schemas":  []any{"urn:ietf:params:scim:schemas:core:2.0:User"},
+				"name": map[string]any{
+					"familyName": "Test-V3",
+					"givenName":  "Old",
+					"nested": map[string]any{
+						"keep": "value",
+					},
+				},
+			},
+		},
+		{
+			name: "replace top-level attributes deep merges nested maps",
+			in: map[string]any{
+				"profile": map[string]any{
+					"name": map[string]any{
+						"givenName": "Old",
+						"familyName": "Value",
+					},
+				},
+			},
+			ops: []scimpatch.Operation{{
+				Op:   "replace",
+				Path: "",
+				Value: map[string]any{
+					"profile": map[string]any{
+						"name": map[string]any{
+							"familyName": "New",
+						},
+					},
+				},
+			}},
+			out: map[string]any{
+				"profile": map[string]any{
+					"name": map[string]any{
+						"givenName":  "Old",
+						"familyName": "New",
+					},
+				},
+			},
 		},
 		{
 			name: "replace top-level prop",
@@ -96,7 +188,7 @@ func TestPatch(t *testing.T) {
 			name: "uppercase Replace op",
 			in:   map[string]any{"foo": "xxx"},
 			ops:  []scimpatch.Operation{{Op: "Replace", Path: "", Value: map[string]any{"bar": "yyy"}}},
-			out:  map[string]any{"bar": "yyy"},
+			out:  map[string]any{"foo": "xxx", "bar": "yyy"},
 		},
 		{
 			name: "uppercase Add op",


### PR DESCRIPTION
## Summary

- Fixes SCIM PATCH `replace` with empty `path` so we no longer replace the entire user resource object.
- Adds compatibility for providers that send `Operation.value` as either:
  - a JSON object, or
  - a JSON-stringified object.
- Implements deep-merge behavior for top-level object attributes (for example `name`) so partial updates preserve existing nested sibling fields.
- Keeps scalar and array replacement behavior unchanged for top-level attributes.

## Why

Some IdPs send PATCH payloads with:

- `op: "replace"`
- `path: ""`
- partial complex attributes in `value` (sometimes stringified JSON)

Before this change, those requests could fail or overwrite too much data.

## Test Plan

- Added/updated tests in `internal/scimpatch/scimpatch_test.go` for:
  - top-level `replace` with object `value`
  - top-level `replace` with stringified JSON object `value`
  - recursive deep-merge behavior for nested maps
- Verified with:
  - `go test ./internal/scimpatch -count=1`
  - `go test ./internal/authservice -run TestSCIMPatchUser_NestedProperties -count=1`